### PR TITLE
Fix decryption of strings larger than 4 MiB 

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -23,6 +23,14 @@ describe('v1 format', () => {
     expect(received).toEqual(expected)
   })
 
+  test('Encrypt / decript 4 MiB string', async () => {
+    const key = 'k1.aesgcm256.2itF7YmMYIP4b9NNtKMhIx2axGi6aI50RcwGBiFq-VA='
+    const expected = 'a'.repeat(4_194_304) // 2 ** 22 = 4 MiB
+    const cipher = await encryptString(expected, key)
+    const received = await decryptString(cipher, key)
+    expect(received).toEqual(expected)
+  })
+
   test('Encrypt empty string', async () => {
     const key = 'k1.aesgcm256.2itF7YmMYIP4b9NNtKMhIx2axGi6aI50RcwGBiFq-VA='
     const expected = ''

--- a/src/message.ts
+++ b/src/message.ts
@@ -85,7 +85,7 @@ function isBase64(str: string) {
   )
 }
 
-function parseCloakedString(input: CloakedString) {
+export function parseCloakedString(input: CloakedString) {
   const [version, algorithm, fingerprint, iv, ciphertext, nothing] =
     input.split('.')
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -59,6 +59,11 @@ export function encryptStringSync(
 
 // Decryption --
 
+/**
+ * @deprecated
+ *
+ * Causes stack errors on large strings, use {@link parseCloakedString} instead.
+ */
 export const cloakedStringRegex =
   /^v1\.aesgcm256\.(?<fingerprint>[0-9a-fA-F]{8})\.(?<iv>[a-zA-Z0-9-_]{16})\.(?<ciphertext>[a-zA-Z0-9-_]{22,})={0,2}$/
 


### PR DESCRIPTION
The `cloakedStringRegex` fails to parse ciphertexts that are somewhere above 4 MiB large on Node.JS v20.17.0. This is due to [limitations in V8's regex engine][1].

This causes an error:

```
RangeError: Maximum call stack size exceeded
```

I've adapted the `isBase64` function from https://github.com/validatorjs/validator.js/pull/503 under the MIT license, as it solves the error by using a much simpler regex.

[1]: https://issues.chromium.org/issues/42207207

### Implementation details

By the way, I've split up this PR into:

- a `fix:` commit (which fixes the bug), and
- two `feat:` commits:
  - one that exports the `parseCloakedString` function, and another that
  - deprecates the `cloakedStringRegex` in favor of the parseCloakedString` function.

    This isn't actually a "feature", but [Semantic Versioning 2.0.0](https://semver.org/#spec-item-7) specifies that:
    > [Minor version] MUST be incremented if any public API functionality is marked as deprecated.

This should hopefully make a really nice release note in https://github.com/47ng/cloak/releases!

The `parseCloakedString` needs to be exported, so that `prisma-field-encryption` can use it instead of the `cloakedStringRegex`: https://github.com/47ng/prisma-field-encryption/blob/c17354c747562857bf73fabe1c4c3a0c91380580/src/encryption.ts#L179